### PR TITLE
Add Prowler detection coverage to 64 attack paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 **The definitive source of truth for AWS IAM privilege escalation paths**
 
-[![Validate Schema](https://github.com/DataDog/pathfinding.cloud/actions/workflows/validate.yml/badge.svg)](https://github.com/DataDog/pathfinding.cloud/actions/workflows/validate.yml)
-[![Deploy to GitHub Pages](https://github.com/DataDog/pathfinding.cloud/actions/workflows/deploy.yml/badge.svg)](https://github.com/DataDog/pathfinding.cloud/actions/workflows/deploy.yml)
-
 **Website:** [https://pathfinding.cloud](https://pathfinding.cloud)
 
 ## Overview

--- a/data/paths/apprunner/apprunner-001.yaml
+++ b/data/paths/apprunner/apprunner-001.yaml
@@ -92,6 +92,8 @@ relatedPaths:
 - apprunner-002
 - lambda-001
 - ec2-001
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L287
 toolSupport:
   pmapper: false
   iamVulnerable: false

--- a/data/paths/apprunner/apprunner-002.yaml
+++ b/data/paths/apprunner/apprunner-002.yaml
@@ -91,6 +91,8 @@ relatedPaths:
 - apprunner-001
 - lambda-003
 - glue-002
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L292
 permissions:
   required:
   - permission: apprunner:UpdateService

--- a/data/paths/bedrock/bedrock-001.yaml
+++ b/data/paths/bedrock/bedrock-001.yaml
@@ -157,7 +157,7 @@ relatedPaths:
 - ec2-001
 - sagemaker-001
 detectionTools:
-  prowler: https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L106
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L294
 learningEnvironments:
   pathfinding-labs:
     type: open-source

--- a/data/paths/bedrock/bedrock-002.yaml
+++ b/data/paths/bedrock/bedrock-002.yaml
@@ -116,6 +116,8 @@ relatedPaths:
 - lambda-003
 - glue-002
 - ec2-002
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L300
 permissions:
   required:
   - permission: bedrock-agentcore:StartCodeInterpreterSession

--- a/data/paths/cloudformation/cloudformation-001.yaml
+++ b/data/paths/cloudformation/cloudformation-001.yaml
@@ -85,7 +85,7 @@ relatedPaths:
 detectionTools:
   pmapper: https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/cloudformation_edges.py#L109-L132
   cloudsplaining: https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L152
-  prowler: https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L60
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L169
 learningEnvironments:
   pathfinding-labs:
     type: open-source

--- a/data/paths/cloudformation/cloudformation-002.yaml
+++ b/data/paths/cloudformation/cloudformation-002.yaml
@@ -187,6 +187,7 @@ learningEnvironments:
     description: Deploy Terraform into your own AWS account and practice individual exploitation paths (requires CloudFormation non-free module, ~$0.40/month)
 detectionTools:
   pmapper: https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/cloudformation_edges.py#L149
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L174
 attackVisualization:
   nodes:
   - id: start

--- a/data/paths/cloudformation/cloudformation-003.yaml
+++ b/data/paths/cloudformation/cloudformation-003.yaml
@@ -5,6 +5,8 @@ services:
 - iam
 - cloudformation
 
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L175
 permissions:
   required:
   - permission: iam:PassRole

--- a/data/paths/cloudformation/cloudformation-004.yaml
+++ b/data/paths/cloudformation/cloudformation-004.yaml
@@ -5,6 +5,8 @@ services:
 - iam
 - cloudformation
 
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L181
 permissions:
   required:
   - permission: iam:PassRole

--- a/data/paths/cloudformation/cloudformation-005.yaml
+++ b/data/paths/cloudformation/cloudformation-005.yaml
@@ -172,6 +172,7 @@ relatedPaths:
 - cloudformation-004
 detectionTools:
   pmapper: https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/cloudformation_edges.py#L188-L210
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L186
 learningEnvironments:
   pathfinding-labs:
     type: open-source

--- a/data/paths/codebuild/codebuild-001.yaml
+++ b/data/paths/codebuild/codebuild-001.yaml
@@ -92,6 +92,7 @@ relatedPaths:
 - cloudformation-001
 detectionTools:
   pmapper: https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/codebuild_edges.py#L216
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L203
 learningEnvironments:
   pathfinding-labs:
     type: open-source

--- a/data/paths/codebuild/codebuild-002.yaml
+++ b/data/paths/codebuild/codebuild-002.yaml
@@ -82,6 +82,7 @@ relatedPaths:
 - iam-002
 detectionTools:
   pmapper: https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/codebuild_edges.py#L165-L173
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L214
 learningEnvironments:
   pathfinding-labs:
     type: open-source

--- a/data/paths/codebuild/codebuild-003.yaml
+++ b/data/paths/codebuild/codebuild-003.yaml
@@ -103,6 +103,7 @@ relatedPaths:
 - iam-002
 detectionTools:
   pmapper: https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/codebuild_edges.py#L186
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L216
 learningEnvironments:
   pathfinding-labs:
     type: open-source

--- a/data/paths/codebuild/codebuild-004.yaml
+++ b/data/paths/codebuild/codebuild-004.yaml
@@ -76,6 +76,7 @@ references:
   url: https://cloud.hacktricks.wiki/en/pentesting-cloud/aws-security/aws-privilege-escalation/aws-codebuild-privesc/index.html#codebuildstartbuild--codebuildstartbuildbatch
 detectionTools:
   pmapper: https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/codebuild_edges.py#L186
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L208
 relatedPaths:
 - codebuild-001
 - codebuild-003

--- a/data/paths/datapipeline/datapipeline-001.yaml
+++ b/data/paths/datapipeline/datapipeline-001.yaml
@@ -108,7 +108,7 @@ permissions:
   - permission: iam:GetRole
     resourceConstraints: Useful for viewing role trust policies and attached permissions
 detectionTools:
-  prowler: https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L64
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L191
 attackVisualization:
   nodes:
   - id: start

--- a/data/paths/ec2-instance-connect/ec2instanceconnect-003.yaml
+++ b/data/paths/ec2-instance-connect/ec2instanceconnect-003.yaml
@@ -98,6 +98,8 @@ relatedPaths:
 - ec2-001
 - ec2-002
 - ssm-001
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L98
 learningEnvironments:
   pathfinding-labs:
     type: open-source

--- a/data/paths/ec2/ec2-001.yaml
+++ b/data/paths/ec2/ec2-001.yaml
@@ -91,7 +91,7 @@ detectionTools:
   pmapper: https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/ec2_edges.py#L73-L127
   pacu: https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L600
   cloudsplaining: https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L128
-  prowler: https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L26-L30
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L77
 learningEnvironments:
   pathfinding-labs:
     type: open-source

--- a/data/paths/ec2/ec2-002.yaml
+++ b/data/paths/ec2/ec2-002.yaml
@@ -64,6 +64,8 @@ references:
   url: https://bishopfox.com/blog/privilege-escalation-in-aws
 - title: HackTricks - AWS - EC2 Privesc
   url: https://cloud.hacktricks.wiki/en/pentesting-cloud/aws-security/aws-privilege-escalation/aws-ec2-privesc/index.html#ec2modifyinstanceattribute
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L86
 permissions:
   required:
   - permission: ec2:ModifyInstanceAttribute

--- a/data/paths/ec2/ec2-003.yaml
+++ b/data/paths/ec2/ec2-003.yaml
@@ -4,6 +4,8 @@ category: new-passrole
 services:
 - iam
 - ec2
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L81
 permissions:
   required:
   - permission: iam:PassRole

--- a/data/paths/ec2/ec2-004.yaml
+++ b/data/paths/ec2/ec2-004.yaml
@@ -5,6 +5,8 @@ services:
 - ec2
 - iam
 
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L92
 permissions:
   required:
   - permission: "ec2:CreateLaunchTemplateVersion"

--- a/data/paths/ecs/ecs-001.yaml
+++ b/data/paths/ecs/ecs-001.yaml
@@ -8,6 +8,8 @@ services:
 - iam
 - ecs
 
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L230
 permissions:
   required:
   - permission: iam:PassRole

--- a/data/paths/ecs/ecs-002.yaml
+++ b/data/paths/ecs/ecs-002.yaml
@@ -8,6 +8,8 @@ services:
 - iam
 - ecs
 
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L235
 permissions:
   required:
   - permission: iam:PassRole

--- a/data/paths/ecs/ecs-003.yaml
+++ b/data/paths/ecs/ecs-003.yaml
@@ -123,6 +123,8 @@ relatedPaths:
 - lambda-001
 - ecs-001
 - ecs-002
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L230
 learningEnvironments:
   pathfinding-labs:
     type: open-source

--- a/data/paths/ecs/ecs-004.yaml
+++ b/data/paths/ecs/ecs-004.yaml
@@ -100,6 +100,8 @@ references:
 - title: "HackTricks - AWS - ECS Privesc"
   url: "https://cloud.hacktricks.wiki/en/pentesting-cloud/aws-security/aws-privilege-escalation/aws-ecs-privesc/index.html#iampassrole-ecsregistertaskdefinition-ecsruntask"
 
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L235
 permissions:
   required:
   - permission: iam:PassRole

--- a/data/paths/ecs/ecs-005.yaml
+++ b/data/paths/ecs/ecs-005.yaml
@@ -110,6 +110,8 @@ relatedPaths:
 - lambda-001
 - codebuild-001
 - cloudformation-001
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L240
 permissions:
   required:
   - permission: iam:PassRole

--- a/data/paths/glue/glue-001.yaml
+++ b/data/paths/glue/glue-001.yaml
@@ -88,7 +88,7 @@ relatedPaths:
 - lambda-001
 detectionTools:
   cloudsplaining: https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L147-L150
-  prowler: https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L50
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L140
 learningEnvironments:
   pathfinding-labs:
     type: open-source

--- a/data/paths/glue/glue-002.yaml
+++ b/data/paths/glue/glue-002.yaml
@@ -79,7 +79,7 @@ relatedPaths:
 detectionTools:
   cloudsplaining: https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L159
   pacu: https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L468
-  prowler: https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L69
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L145
 learningEnvironments:
   pathfinding-labs:
     type: open-source

--- a/data/paths/glue/glue-003.yaml
+++ b/data/paths/glue/glue-003.yaml
@@ -5,6 +5,8 @@ services:
 - iam
 - glue
 
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L146
 permissions:
   required:
   - permission: "iam:PassRole"

--- a/data/paths/glue/glue-004.yaml
+++ b/data/paths/glue/glue-004.yaml
@@ -5,6 +5,8 @@ services:
 - iam
 - glue
 
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L151
 permissions:
   required:
   - permission: "iam:PassRole"

--- a/data/paths/glue/glue-005.yaml
+++ b/data/paths/glue/glue-005.yaml
@@ -5,6 +5,8 @@ services:
 - iam
 - glue
 
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L157
 permissions:
   required:
   - permission: "iam:PassRole"

--- a/data/paths/glue/glue-006.yaml
+++ b/data/paths/glue/glue-006.yaml
@@ -4,6 +4,8 @@ category: new-passrole
 services:
 - iam
 - glue
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L163
 permissions:
   required:
   - permission: iam:PassRole

--- a/data/paths/iam/iam-001.yaml
+++ b/data/paths/iam/iam-001.yaml
@@ -46,7 +46,7 @@ relatedPaths:
 detectionTools:
   cloudsplaining: https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L117
   pacu: https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L273
-  prowler: https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L25
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L27
 detectionRules:
 - platform: CloudSIEM
   url: https://docs.datadoghq.com/security/default_rules/7b6-2a8-df9/

--- a/data/paths/iam/iam-002.yaml
+++ b/data/paths/iam/iam-002.yaml
@@ -57,7 +57,7 @@ detectionTools:
   pmapper: https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/iam_edges.py#L70
   cloudsplaining: https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L112
   pacu: https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L218
-  prowler: https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L86
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L29
 learningEnvironments:
   pathfinding-labs:
     type: open-source

--- a/data/paths/iam/iam-003.yaml
+++ b/data/paths/iam/iam-003.yaml
@@ -52,6 +52,7 @@ relatedPaths:
 - iam-002
 detectionTools:
   pmapper: https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/iam_edges.py#L63-L85
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L41
 learningEnvironments:
   pathfinding-labs:
     type: open-source

--- a/data/paths/iam/iam-004.yaml
+++ b/data/paths/iam/iam-004.yaml
@@ -70,7 +70,7 @@ detectionTools:
   pmapper: https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/iam_edges.py#L116
   cloudsplaining: https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L113
   pacu: https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L256
-  prowler: https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L87
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L30
 attackVisualization:
   nodes:
   - id: start

--- a/data/paths/iam/iam-005.yaml
+++ b/data/paths/iam/iam-005.yaml
@@ -90,7 +90,7 @@ relatedPaths:
 detectionTools:
   cloudsplaining: https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L124
   pacu: https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L423
-  prowler: https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L94
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L36
 learningEnvironments:
   pathfinding-labs:
     type: open-source

--- a/data/paths/iam/iam-006.yaml
+++ b/data/paths/iam/iam-006.yaml
@@ -70,7 +70,7 @@ detectionTools:
   pmapper: https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/iam_edges.py#L108
   cloudsplaining: https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L114
   pacu: https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L479
-  prowler: https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L88
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L31
 attackVisualization:
   nodes:
   - id: start

--- a/data/paths/iam/iam-007.yaml
+++ b/data/paths/iam/iam-007.yaml
@@ -43,7 +43,7 @@ relatedPaths:
 detectionTools:
   cloudsplaining: https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L122
   pacu: https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L437
-  prowler: https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L96
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L37
 detectionRules:
 - platform: CloudSIEM
   url: https://docs.datadoghq.com/security/default_rules/7b6-2a8-df9/

--- a/data/paths/iam/iam-008.yaml
+++ b/data/paths/iam/iam-008.yaml
@@ -43,7 +43,7 @@ relatedPaths:
 detectionTools:
   cloudsplaining: https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L119
   pacu: https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L190
-  prowler: https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L89
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L32
 detectionRules:
 - platform: CloudSIEM
   url: https://docs.datadoghq.com/security/default_rules/7b6-2a8-df9/

--- a/data/paths/iam/iam-009.yaml
+++ b/data/paths/iam/iam-009.yaml
@@ -42,7 +42,7 @@ relatedPaths:
 detectionTools:
   cloudsplaining: https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L121
   pacu: https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L176
-  prowler: https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L91
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L34
 detectionRules:
 - platform: CloudSIEM
   url: https://docs.datadoghq.com/security/default_rules/7b6-2a8-df9/

--- a/data/paths/iam/iam-010.yaml
+++ b/data/paths/iam/iam-010.yaml
@@ -43,7 +43,7 @@ relatedPaths:
 detectionTools:
   cloudsplaining: https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L120
   pacu: https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L162
-  prowler: https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L90
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L33
 detectionRules:
 - platform: CloudSIEM
   url: https://docs.datadoghq.com/security/default_rules/7b6-2a8-df9/

--- a/data/paths/iam/iam-011.yaml
+++ b/data/paths/iam/iam-011.yaml
@@ -43,7 +43,7 @@ relatedPaths:
 detectionTools:
   cloudsplaining: https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L123
   pacu: https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L409
-  prowler: https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L93
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L35
 detectionRules:
 - platform: CloudSIEM
   url: https://docs.datadoghq.com/security/default_rules/7b6-2a8-df9/

--- a/data/paths/iam/iam-012.yaml
+++ b/data/paths/iam/iam-012.yaml
@@ -46,7 +46,7 @@ detectionTools:
   pmapper: https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/iam_edges.py#L131
   cloudsplaining: https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L126
   pacu: https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L498
-  prowler: https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L98
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L39
 detectionRules:
 - platform: CloudSIEM
   url: https://docs.datadoghq.com/security/default_rules/7b6-2a8-df9/

--- a/data/paths/iam/iam-013.yaml
+++ b/data/paths/iam/iam-013.yaml
@@ -64,7 +64,7 @@ relatedPaths:
 detectionTools:
   cloudsplaining: https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L115
   pacu: https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L572
-  prowler: https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L97
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L38
 learningEnvironments:
   pathfinding-labs:
     type: open-source

--- a/data/paths/iam/iam-014.yaml
+++ b/data/paths/iam/iam-014.yaml
@@ -148,7 +148,7 @@ references:
 detectionTools:
   cloudsplaining: https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L121
   pacu: https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L580
-  prowler: https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L91
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L66
 learningEnvironments:
   pathfinding-labs:
     type: open-source

--- a/data/paths/iam/iam-015.yaml
+++ b/data/paths/iam/iam-015.yaml
@@ -6,6 +6,8 @@ name: iam:AttachUserPolicy + iam:CreateAccessKey
 category: principal-access
 services:
 - iam
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L45
 permissions:
   required:
   - permission: iam:AttachUserPolicy

--- a/data/paths/iam/iam-016.yaml
+++ b/data/paths/iam/iam-016.yaml
@@ -7,6 +7,8 @@ category: principal-access
 services:
 - iam
 - sts
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L72
 permissions:
   required:
   - permission: iam:CreatePolicyVersion

--- a/data/paths/iam/iam-017.yaml
+++ b/data/paths/iam/iam-017.yaml
@@ -181,7 +181,7 @@ relatedPaths:
 - iam-014
 - iam-016
 detectionTools:
-    prowler: https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L95
+    prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L67
 learningEnvironments:
 detectionRules:
 - platform: CloudTrail

--- a/data/paths/iam/iam-018.yaml
+++ b/data/paths/iam/iam-018.yaml
@@ -7,6 +7,8 @@ category: "principal-access"
 services:
 - iam
 
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L49
 permissions:
   required:
   - permission: "iam:PutUserPolicy"

--- a/data/paths/iam/iam-019.yaml
+++ b/data/paths/iam/iam-019.yaml
@@ -6,6 +6,8 @@ name: iam:AttachRolePolicy + iam:UpdateAssumeRolePolicy
 category: principal-access
 services:
 - iam
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L53
 permissions:
   required:
   - permission: iam:AttachRolePolicy

--- a/data/paths/iam/iam-020.yaml
+++ b/data/paths/iam/iam-020.yaml
@@ -7,6 +7,8 @@ category: "principal-access"
 services:
 - iam
 
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L57
 permissions:
   required:
   - permission: "iam:CreatePolicyVersion"

--- a/data/paths/iam/iam-021.yaml
+++ b/data/paths/iam/iam-021.yaml
@@ -6,6 +6,8 @@ name: iam:PutRolePolicy + iam:UpdateAssumeRolePolicy
 category: principal-access
 services:
 - iam
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L61
 permissions:
   required:
   - permission: iam:PutRolePolicy

--- a/data/paths/lambda/lambda-001.yaml
+++ b/data/paths/lambda/lambda-001.yaml
@@ -95,7 +95,7 @@ relatedPaths:
 - cloudformation-001
 detectionTools:
   cloudsplaining: https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L131
-  prowler: https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L34
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L103
 learningEnvironments:
   pathfinding-labs:
     type: open-source

--- a/data/paths/lambda/lambda-002.yaml
+++ b/data/paths/lambda/lambda-002.yaml
@@ -89,6 +89,7 @@ relatedPaths:
 - lambda-003      
 detectionTools:
   pacu: https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L655
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L108
 learningEnvironments:
   pathfinding-labs:
     type: open-source

--- a/data/paths/lambda/lambda-003.yaml
+++ b/data/paths/lambda/lambda-003.yaml
@@ -88,7 +88,7 @@ detectionTools:
   pmapper: https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/lambda_edges.py#L152-L172
   cloudsplaining: https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L160
   pacu: https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L616
-  prowler: https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L70
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L126
 learningEnvironments:
   pathfinding-labs:
     type: open-source

--- a/data/paths/lambda/lambda-004.yaml
+++ b/data/paths/lambda/lambda-004.yaml
@@ -81,7 +81,7 @@ relatedPaths:
 - lambda-003
 detectionTools:
   pacu: https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L616C10-L616C29
-  prowler: https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L34
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L130
 learningEnvironments:
   pathfinding-labs:
     type: open-source

--- a/data/paths/lambda/lambda-005.yaml
+++ b/data/paths/lambda/lambda-005.yaml
@@ -6,6 +6,8 @@ name: lambda:UpdateFunctionCode + lambda:AddPermission
 category: existing-passrole
 services:
 - lambda
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L135
 permissions:
   required:
   - permission: lambda:UpdateFunctionCode

--- a/data/paths/lambda/lambda-006.yaml
+++ b/data/paths/lambda/lambda-006.yaml
@@ -160,6 +160,7 @@ references:
   url: https://blog.the1ntern.net/aws/privesc/xacclambdainvoke/
 detectionTools:
   pacu: https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L287
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L120
 learningEnvironments:
   pathfinding-labs:
     type: open-source

--- a/data/paths/sagemaker/sagemaker-001.yaml
+++ b/data/paths/sagemaker/sagemaker-001.yaml
@@ -61,6 +61,7 @@ limitations: |
   This path provides administrative access only if the passed role has administrative permissions (e.g., AdministratorAccess or an equivalent custom policy). If only limited roles are available, you gain access limited to those permissions. However, even limited access may enable multi-hop attacks or access to sensitive data.
 detectionTools:
   pmapper: https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/sagemaker_edges.py#L94
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L258
 discoveryAttribution:
   firstDocumented:
     author: Spencer Gietzen

--- a/data/paths/sagemaker/sagemaker-002.yaml
+++ b/data/paths/sagemaker/sagemaker-002.yaml
@@ -107,6 +107,7 @@ relatedPaths:
 - sagemaker-003
 detectionTools:
   pmapper: https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/sagemaker_edges.py#L111
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L262
 learningEnvironments:
   iam-vulnerable:
     type: open-source

--- a/data/paths/sagemaker/sagemaker-003.yaml
+++ b/data/paths/sagemaker/sagemaker-003.yaml
@@ -101,6 +101,7 @@ relatedPaths:
 - sagemaker-002
 detectionTools:
   pmapper: https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/sagemaker_edges.py#L127
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L266
 learningEnvironments:
   iam-vulnerable:
     type: open-source

--- a/data/paths/sagemaker/sagemaker-004.yaml
+++ b/data/paths/sagemaker/sagemaker-004.yaml
@@ -72,6 +72,8 @@ references:
   url: https://cloud.hacktricks.wiki/en/pentesting-cloud/aws-security/aws-privilege-escalation/aws-sagemaker-privesc/index.html#sagemakercreatepresignednotebookinstanceurl
 relatedPaths:
 - sagemaker-001
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L271
 learningEnvironments:
   iam-vulnerable:
     type: open-source

--- a/data/paths/sagemaker/sagemaker-005.yaml
+++ b/data/paths/sagemaker/sagemaker-005.yaml
@@ -5,6 +5,8 @@ services:
   - sagemaker
   - iam
 
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L275
 permissions:
   required:
     - permission: sagemaker:CreateNotebookInstanceLifecycleConfig

--- a/data/paths/ssm/ssm-001.yaml
+++ b/data/paths/ssm/ssm-001.yaml
@@ -57,6 +57,7 @@ relatedPaths:
 - ssm-002
 detectionTools:
   pmapper: https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/ssm_edges.py#L103-L110
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L283
 learningEnvironments:
   pathfinding-labs:
     type: open-source

--- a/data/paths/ssm/ssm-002.yaml
+++ b/data/paths/ssm/ssm-002.yaml
@@ -65,6 +65,7 @@ learningEnvironments:
       exploitation paths
 detectionTools:
   pmapper: https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/ssm_edges.py#L85-L95
+  prowler: https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L285
 permissions:
   required:
   - permission: ssm:SendCommand

--- a/docs/metadata.json
+++ b/docs/metadata.json
@@ -1,26 +1,26 @@
 {
   "totalPaths": 66,
   "services": [
-    "lambda",
-    "sts",
-    "glue",
-    "bedrock-agentcore",
-    "iam",
-    "ssm",
-    "codebuild",
-    "ecs",
-    "sagemaker",
-    "datapipeline",
-    "cloudformation",
-    "ec2",
     "apprunner",
-    "ec2-instance-connect"
+    "glue",
+    "codebuild",
+    "ec2-instance-connect",
+    "bedrock-agentcore",
+    "ec2",
+    "ecs",
+    "lambda",
+    "sagemaker",
+    "iam",
+    "cloudformation",
+    "ssm",
+    "datapipeline",
+    "sts"
   ],
   "categories": [
     "existing-passrole",
-    "principal-access",
     "self-escalation",
-    "new-passrole"
+    "new-passrole",
+    "principal-access"
   ],
   "lastUpdated": null
 }

--- a/docs/paths.json
+++ b/docs/paths.json
@@ -71,6 +71,9 @@
       "lambda-001",
       "ec2-001"
     ],
+    "detectionTools": {
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L287"
+    },
     "toolSupport": {
       "pmapper": false,
       "iamVulnerable": false
@@ -372,6 +375,9 @@
       "lambda-003",
       "glue-002"
     ],
+    "detectionTools": {
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L292"
+    },
     "permissions": {
       "required": [
         {
@@ -680,7 +686,7 @@
       "sagemaker-001"
     ],
     "detectionTools": {
-      "prowler": "https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L106"
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L294"
     },
     "learningEnvironments": {
       "pathfinding-labs": {
@@ -927,6 +933,9 @@
       "glue-002",
       "ec2-002"
     ],
+    "detectionTools": {
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L300"
+    },
     "permissions": {
       "required": [
         {
@@ -1184,7 +1193,7 @@
     "detectionTools": {
       "pmapper": "https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/cloudformation_edges.py#L109-L132",
       "cloudsplaining": "https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L152",
-      "prowler": "https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L60"
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L169"
     },
     "learningEnvironments": {
       "pathfinding-labs": {
@@ -1485,7 +1494,8 @@
       }
     },
     "detectionTools": {
-      "pmapper": "https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/cloudformation_edges.py#L149"
+      "pmapper": "https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/cloudformation_edges.py#L149",
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L174"
     },
     "attackVisualization": {
       "nodes": [
@@ -1581,6 +1591,9 @@
       "iam",
       "cloudformation"
     ],
+    "detectionTools": {
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L175"
+    },
     "permissions": {
       "required": [
         {
@@ -1832,6 +1845,9 @@
       "iam",
       "cloudformation"
     ],
+    "detectionTools": {
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L181"
+    },
     "permissions": {
       "required": [
         {
@@ -2211,7 +2227,8 @@
       "cloudformation-004"
     ],
     "detectionTools": {
-      "pmapper": "https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/cloudformation_edges.py#L188-L210"
+      "pmapper": "https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/cloudformation_edges.py#L188-L210",
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L186"
     },
     "learningEnvironments": {
       "pathfinding-labs": {
@@ -2428,7 +2445,8 @@
       "cloudformation-001"
     ],
     "detectionTools": {
-      "pmapper": "https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/codebuild_edges.py#L216"
+      "pmapper": "https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/codebuild_edges.py#L216",
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L203"
     },
     "learningEnvironments": {
       "pathfinding-labs": {
@@ -2656,7 +2674,8 @@
       "iam-002"
     ],
     "detectionTools": {
-      "pmapper": "https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/codebuild_edges.py#L165-L173"
+      "pmapper": "https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/codebuild_edges.py#L165-L173",
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L214"
     },
     "learningEnvironments": {
       "pathfinding-labs": {
@@ -2889,7 +2908,8 @@
       "iam-002"
     ],
     "detectionTools": {
-      "pmapper": "https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/codebuild_edges.py#L186"
+      "pmapper": "https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/codebuild_edges.py#L186",
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L216"
     },
     "learningEnvironments": {
       "pathfinding-labs": {
@@ -3109,7 +3129,8 @@
       }
     ],
     "detectionTools": {
-      "pmapper": "https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/codebuild_edges.py#L186"
+      "pmapper": "https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/codebuild_edges.py#L186",
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L208"
     },
     "relatedPaths": [
       "codebuild-001",
@@ -3382,7 +3403,7 @@
       ]
     },
     "detectionTools": {
-      "prowler": "https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L64"
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L191"
     },
     "attackVisualization": {
       "nodes": [
@@ -3575,7 +3596,7 @@
       "pmapper": "https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/ec2_edges.py#L73-L127",
       "pacu": "https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L600",
       "cloudsplaining": "https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L128",
-      "prowler": "https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L26-L30"
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L77"
     },
     "learningEnvironments": {
       "pathfinding-labs": {
@@ -3865,6 +3886,9 @@
         "url": "https://cloud.hacktricks.wiki/en/pentesting-cloud/aws-security/aws-privilege-escalation/aws-ec2-privesc/index.html#ec2modifyinstanceattribute"
       }
     ],
+    "detectionTools": {
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L86"
+    },
     "permissions": {
       "required": [
         {
@@ -4046,6 +4070,9 @@
       "iam",
       "ec2"
     ],
+    "detectionTools": {
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L81"
+    },
     "permissions": {
       "required": [
         {
@@ -4300,6 +4327,9 @@
       "ec2",
       "iam"
     ],
+    "detectionTools": {
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L92"
+    },
     "permissions": {
       "required": [
         {
@@ -4652,6 +4682,9 @@
       "ec2-002",
       "ssm-001"
     ],
+    "detectionTools": {
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L98"
+    },
     "learningEnvironments": {
       "pathfinding-labs": {
         "type": "open-source",
@@ -4796,6 +4829,9 @@
       "iam",
       "ecs"
     ],
+    "detectionTools": {
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L230"
+    },
     "permissions": {
       "required": [
         {
@@ -5068,6 +5104,9 @@
       "iam",
       "ecs"
     ],
+    "detectionTools": {
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L235"
+    },
     "permissions": {
       "required": [
         {
@@ -5398,6 +5437,9 @@
       "ecs-001",
       "ecs-002"
     ],
+    "detectionTools": {
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L230"
+    },
     "learningEnvironments": {
       "pathfinding-labs": {
         "type": "open-source",
@@ -5648,6 +5690,9 @@
         "url": "https://cloud.hacktricks.wiki/en/pentesting-cloud/aws-security/aws-privilege-escalation/aws-ecs-privesc/index.html#iampassrole-ecsregistertaskdefinition-ecsruntask"
       }
     ],
+    "detectionTools": {
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L235"
+    },
     "permissions": {
       "required": [
         {
@@ -5915,6 +5960,9 @@
       "codebuild-001",
       "cloudformation-001"
     ],
+    "detectionTools": {
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L240"
+    },
     "permissions": {
       "required": [
         {
@@ -6402,7 +6450,7 @@
     ],
     "detectionTools": {
       "cloudsplaining": "https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L147-L150",
-      "prowler": "https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L50"
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L140"
     },
     "learningEnvironments": {
       "pathfinding-labs": {
@@ -6627,7 +6675,7 @@
     "detectionTools": {
       "cloudsplaining": "https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L159",
       "pacu": "https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L468",
-      "prowler": "https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L69"
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L145"
     },
     "learningEnvironments": {
       "pathfinding-labs": {
@@ -6771,6 +6819,9 @@
       "iam",
       "glue"
     ],
+    "detectionTools": {
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L146"
+    },
     "permissions": {
       "required": [
         {
@@ -7021,6 +7072,9 @@
       "iam",
       "glue"
     ],
+    "detectionTools": {
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L151"
+    },
     "permissions": {
       "required": [
         {
@@ -7280,6 +7334,9 @@
       "iam",
       "glue"
     ],
+    "detectionTools": {
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L157"
+    },
     "permissions": {
       "required": [
         {
@@ -7542,6 +7599,9 @@
       "iam",
       "glue"
     ],
+    "detectionTools": {
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L163"
+    },
     "permissions": {
       "required": [
         {
@@ -7864,7 +7924,7 @@
     "detectionTools": {
       "cloudsplaining": "https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L117",
       "pacu": "https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L273",
-      "prowler": "https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L25"
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L27"
     },
     "detectionRules": [
       {
@@ -8032,7 +8092,7 @@
       "pmapper": "https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/iam_edges.py#L70",
       "cloudsplaining": "https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L112",
       "pacu": "https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L218",
-      "prowler": "https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L86"
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L29"
     },
     "learningEnvironments": {
       "pathfinding-labs": {
@@ -8238,7 +8298,8 @@
       "iam-002"
     ],
     "detectionTools": {
-      "pmapper": "https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/iam_edges.py#L63-L85"
+      "pmapper": "https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/iam_edges.py#L63-L85",
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L41"
     },
     "learningEnvironments": {
       "pathfinding-labs": {
@@ -8471,7 +8532,7 @@
       "pmapper": "https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/iam_edges.py#L116",
       "cloudsplaining": "https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L113",
       "pacu": "https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L256",
-      "prowler": "https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L87"
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L30"
     },
     "attackVisualization": {
       "nodes": [
@@ -8663,7 +8724,7 @@
     "detectionTools": {
       "cloudsplaining": "https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L124",
       "pacu": "https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L423",
-      "prowler": "https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L94"
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L36"
     },
     "learningEnvironments": {
       "pathfinding-labs": {
@@ -8820,7 +8881,7 @@
       "pmapper": "https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/iam_edges.py#L108",
       "cloudsplaining": "https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L114",
       "pacu": "https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L479",
-      "prowler": "https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L88"
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L31"
     },
     "attackVisualization": {
       "nodes": [
@@ -8983,7 +9044,7 @@
     "detectionTools": {
       "cloudsplaining": "https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L122",
       "pacu": "https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L437",
-      "prowler": "https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L96"
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L37"
     },
     "detectionRules": [
       {
@@ -9119,7 +9180,7 @@
     "detectionTools": {
       "cloudsplaining": "https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L119",
       "pacu": "https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L190",
-      "prowler": "https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L89"
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L32"
     },
     "detectionRules": [
       {
@@ -9304,7 +9365,7 @@
     "detectionTools": {
       "cloudsplaining": "https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L121",
       "pacu": "https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L176",
-      "prowler": "https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L91"
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L34"
     },
     "detectionRules": [
       {
@@ -9439,7 +9500,7 @@
     "detectionTools": {
       "cloudsplaining": "https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L120",
       "pacu": "https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L162",
-      "prowler": "https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L90"
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L33"
     },
     "detectionRules": [
       {
@@ -9586,7 +9647,7 @@
     "detectionTools": {
       "cloudsplaining": "https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L123",
       "pacu": "https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L409",
-      "prowler": "https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L93"
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L35"
     },
     "detectionRules": [
       {
@@ -9718,7 +9779,7 @@
       "pmapper": "https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/iam_edges.py#L131",
       "cloudsplaining": "https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L126",
       "pacu": "https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L498",
-      "prowler": "https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L98"
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L39"
     },
     "detectionRules": [
       {
@@ -9920,7 +9981,7 @@
     "detectionTools": {
       "cloudsplaining": "https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L115",
       "pacu": "https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L572",
-      "prowler": "https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L97"
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L38"
     },
     "learningEnvironments": {
       "pathfinding-labs": {
@@ -10159,7 +10220,7 @@
     "detectionTools": {
       "cloudsplaining": "https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L121",
       "pacu": "https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L580",
-      "prowler": "https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L91"
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L66"
     },
     "learningEnvironments": {
       "pathfinding-labs": {
@@ -10259,6 +10320,9 @@
     "services": [
       "iam"
     ],
+    "detectionTools": {
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L45"
+    },
     "permissions": {
       "required": [
         {
@@ -10509,6 +10573,9 @@
       "iam",
       "sts"
     ],
+    "detectionTools": {
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L72"
+    },
     "permissions": {
       "required": [
         {
@@ -10910,7 +10977,7 @@
       "iam-016"
     ],
     "detectionTools": {
-      "prowler": "https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L95"
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L67"
     },
     "learningEnvironments": {
       "pathfinding-labs": {
@@ -11005,6 +11072,9 @@
     "services": [
       "iam"
     ],
+    "detectionTools": {
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L49"
+    },
     "permissions": {
       "required": [
         {
@@ -11265,6 +11335,9 @@
     "services": [
       "iam"
     ],
+    "detectionTools": {
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L53"
+    },
     "permissions": {
       "required": [
         {
@@ -11495,6 +11568,9 @@
     "services": [
       "iam"
     ],
+    "detectionTools": {
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L57"
+    },
     "permissions": {
       "required": [
         {
@@ -11740,6 +11816,9 @@
     "services": [
       "iam"
     ],
+    "detectionTools": {
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L61"
+    },
     "permissions": {
       "required": [
         {
@@ -12078,7 +12157,7 @@
     ],
     "detectionTools": {
       "cloudsplaining": "https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L131",
-      "prowler": "https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L34"
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L103"
     },
     "learningEnvironments": {
       "pathfinding-labs": {
@@ -12430,7 +12509,8 @@
       "lambda-003"
     ],
     "detectionTools": {
-      "pacu": "https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L655"
+      "pacu": "https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L655",
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L108"
     },
     "learningEnvironments": {
       "pathfinding-labs": {
@@ -12815,7 +12895,7 @@
       "pmapper": "https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/lambda_edges.py#L152-L172",
       "cloudsplaining": "https://github.com/salesforce/cloudsplaining/blob/7f82e7ab0a1a714d20a69b1d0b892e4702754e6b/cloudsplaining/shared/constants.py#L160",
       "pacu": "https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L616",
-      "prowler": "https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L70"
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L126"
     },
     "learningEnvironments": {
       "pathfinding-labs": {
@@ -13171,7 +13251,7 @@
     ],
     "detectionTools": {
       "pacu": "https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L616C10-L616C29",
-      "prowler": "https://github.com/prowler-cloud/prowler/blob/49c75cc4180e2304747d8fe4bd1b16dd38929d07/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L34"
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L130"
     },
     "learningEnvironments": {
       "pathfinding-labs": {
@@ -13450,6 +13530,9 @@
     "services": [
       "lambda"
     ],
+    "detectionTools": {
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L135"
+    },
     "permissions": {
       "required": [
         {
@@ -13965,7 +14048,8 @@
       }
     ],
     "detectionTools": {
-      "pacu": "https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L287"
+      "pacu": "https://github.com/RhinoSecurityLabs/pacu/blob/50e7ad2d885b7ab4bc130f44b798ca85ed4d7a91/pacu/modules/iam__privesc_scan/main.py#L287",
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L120"
     },
     "learningEnvironments": {
       "pathfinding-labs": {
@@ -14272,7 +14356,8 @@
     "recommendation": "High powered service roles + overly permissive `iam:PassRole` is what makes this privilege escalation path exploitable and impactful.\n\n- **Avoid administrative service roles** - Very rarely does a SageMaker notebook instance need administrative access. Use the principle of least privilege.\n- **Avoid granting `iam:PassRole` on all resources** - Whenever possible, restrict `iam:PassRole` to specific roles or specific services.\n\nUse IAM policy conditions to restrict which roles can be passed and to which services:\n\n```json\n{\n  \"Effect\": \"Allow\",\n  \"Action\": \"iam:PassRole\",\n  \"Resource\": \"arn:aws:iam::ACCOUNT_ID:role/SpecificSageMakerRole\",\n  \"Condition\": {\n    \"StringEquals\": {\n      \"iam:PassedToService\": \"sagemaker.amazonaws.com\"\n    }\n  }\n}\n```\n\n- Monitor CloudTrail for unusual SageMaker notebook creation followed by immediate access\n- Monitor CloudTrail for notebook instance creation by principals who do not usually create notebooks\n- Monitor CloudTrail for roles being passed to SageMaker that haven't been used before\n- Monitor and alert on SageMaker notebook creation with privileged roles\n- Regularly audit SageMaker notebook instances for excessive IAM permissions\n- Regularly audit all IAM roles that trust the SageMaker service and down-scope any roles with administrative access\n",
     "limitations": "This path provides administrative access only if the passed role has administrative permissions (e.g., AdministratorAccess or an equivalent custom policy). If only limited roles are available, you gain access limited to those permissions. However, even limited access may enable multi-hop attacks or access to sensitive data.\n",
     "detectionTools": {
-      "pmapper": "https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/sagemaker_edges.py#L94"
+      "pmapper": "https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/sagemaker_edges.py#L94",
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L258"
     },
     "discoveryAttribution": {
       "firstDocumented": {
@@ -14535,7 +14620,8 @@
       "sagemaker-003"
     ],
     "detectionTools": {
-      "pmapper": "https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/sagemaker_edges.py#L111"
+      "pmapper": "https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/sagemaker_edges.py#L111",
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L262"
     },
     "learningEnvironments": {
       "iam-vulnerable": {
@@ -14763,7 +14849,8 @@
       "sagemaker-002"
     ],
     "detectionTools": {
-      "pmapper": "https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/sagemaker_edges.py#L127"
+      "pmapper": "https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/sagemaker_edges.py#L127",
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L266"
     },
     "learningEnvironments": {
       "iam-vulnerable": {
@@ -14976,6 +15063,9 @@
     "relatedPaths": [
       "sagemaker-001"
     ],
+    "detectionTools": {
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L271"
+    },
     "learningEnvironments": {
       "iam-vulnerable": {
         "type": "open-source",
@@ -15112,6 +15202,9 @@
       "sagemaker",
       "iam"
     ],
+    "detectionTools": {
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L275"
+    },
     "permissions": {
       "required": [
         {
@@ -15536,7 +15629,8 @@
       "ssm-002"
     ],
     "detectionTools": {
-      "pmapper": "https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/ssm_edges.py#L103-L110"
+      "pmapper": "https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/ssm_edges.py#L103-L110",
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L283"
     },
     "learningEnvironments": {
       "pathfinding-labs": {
@@ -15799,7 +15893,8 @@
       }
     },
     "detectionTools": {
-      "pmapper": "https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/ssm_edges.py#L85-L95"
+      "pmapper": "https://github.com/nccgroup/PMapper/blob/91d2e60102bdadf346d77b60d90ddaa4a678f037/principalmapper/graphing/ssm_edges.py#L85-L95",
+      "prowler": "https://github.com/prowler-cloud/prowler/blob/eabe4884379070c72e07103f239bac70d31f6320/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L285"
     },
     "permissions": {
       "required": [


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] New Path
- [x] Add / Update / Fix info within an existing path
- [ ] New Feature / Major Change / Refactor / Optimization
- [ ] Non path based documentation Update (Readme, etc)

## Description

Adds Prowler detection tool links to 64 attack paths following the merge of [prowler-cloud/prowler#9922](https://github.com/prowler-cloud/prowler/pull/9922) (commit `eabe488`), which added 50+ privilege escalation patterns from pathfinding.cloud to Prowler's detection engine.

**64 files changed across 3 categories:**

- **23 paths** — Updated existing `prowler:` URLs to reference the new merged commit hash + correct line numbers
- **14 paths** — Added `prowler:` entry to existing `detectionTools` sections
- **27 paths** — Added new `detectionTools` sections with `prowler:` URLs

**Skipped (not covered by Prowler):**
- `ecs-006` (ecs:ExecuteCommand) — Not in Prowler
- `sts-001` (sts:AssumeRole) — Commented out in Prowler, needs resource/condition validation first

## How to reproduce and testing

See the [Adding a New Privilege Escalation Path](https://github.com/DataDog/pathfinding.cloud/blob/main/CONTRIBUTING.md#adding-a-new-privilege-escalation-path) section of our Contributing Guide to see how to test your changes locally. 

```bash
# Validate all files
python scripts/validate-schema.py data/paths/

# All 66 files pass validation
```