### PR TITLE
feat: add Prowler detection coverage to 17 service privesc paths

### DIFF
--- a/data/paths/batch/batch-001.yaml
+++ b/data/paths/batch/batch-001.yaml
@@ -134,6 +134,9 @@ learningEnvironments:
     scenario: "privesc-one-hop/to-admin/batch-001-iam-passrole+batch-registerjobdefinition+batch-submitjob"
     description: "Deploy Terraform scenarios individually or in groups, each with attack and cleanup scripts"
 
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/c610d9ac3157a8ffd3ca43353febc5817e50fb86/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L346
+
 attackVisualization:
   nodes:
     - id: start

--- a/data/paths/batch/batch-002.yaml
+++ b/data/paths/batch/batch-002.yaml
@@ -99,6 +99,9 @@ learningEnvironments:
     scenario: "privesc-one-hop/to-admin/batch-002-batch-submitjob"
     description: "Deploy Terraform scenarios individually or in groups, each with attack and cleanup scripts"
 
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/c610d9ac3157a8ffd3ca43353febc5817e50fb86/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L352
+
 attackVisualization:
   nodes:
     - id: start

--- a/data/paths/braket/braket-001.yaml
+++ b/data/paths/braket/braket-001.yaml
@@ -132,6 +132,9 @@ learningEnvironments:
     scenario: "privesc-one-hop/to-admin/braket-001-iam-passrole+braket-createjob"
     description: "Deploy Terraform scenarios individually or in groups, each with attack and cleanup scripts"
 
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/c610d9ac3157a8ffd3ca43353febc5817e50fb86/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L354
+
 attackVisualization:
   nodes:
     - id: start

--- a/data/paths/codedeploy/codedeploy-001.yaml
+++ b/data/paths/codedeploy/codedeploy-001.yaml
@@ -123,6 +123,9 @@ learningEnvironments:
     scenario: "privesc-one-hop/to-admin/codedeploy-001-codedeploy-createdeployment"
     description: "Deploy Terraform scenarios individually or in groups, each with attack and cleanup scripts"
 
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/c610d9ac3157a8ffd3ca43353febc5817e50fb86/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L360
+
 attackVisualization:
   nodes:
     - id: start

--- a/data/paths/cognitoidentity/cognitoidentity-001.yaml
+++ b/data/paths/cognitoidentity/cognitoidentity-001.yaml
@@ -132,6 +132,9 @@ learningEnvironments:
     scenario: "privesc-one-hop/to-admin/cognito-identity-001-iam-passrole+cognito-identity-setidentitypoolroles"
     description: "Deploy Terraform scenarios individually or in groups, each with attack and cleanup scripts"
 
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/c610d9ac3157a8ffd3ca43353febc5817e50fb86/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L366
+
 attackVisualization:
   nodes:
     - id: start

--- a/data/paths/ecs/ecs-009.yaml
+++ b/data/paths/ecs/ecs-009.yaml
@@ -142,6 +142,9 @@ learningEnvironments:
     scenario: "privesc-one-hop/to-admin/iam-passrole+ecs-starttask"
     description: "Deploy Terraform into your own AWS account to practice this attack path"
 
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/c610d9ac3157a8ffd3ca43353febc5817e50fb86/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L371
+
 attackVisualization:
   nodes:
     - id: start

--- a/data/paths/emr/emr-001.yaml
+++ b/data/paths/emr/emr-001.yaml
@@ -122,6 +122,9 @@ learningEnvironments:
     scenario: "privesc-one-hop/to-admin/emr-001-iam-passrole+elasticmapreduce-runjobflow"
     description: "Deploy Terraform scenarios individually or in groups, each with attack and cleanup scripts"
 
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/c610d9ac3157a8ffd3ca43353febc5817e50fb86/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L376
+
 attackVisualization:
   nodes:
     - id: start

--- a/data/paths/emrserverless/emrserverless-001.yaml
+++ b/data/paths/emrserverless/emrserverless-001.yaml
@@ -141,6 +141,9 @@ learningEnvironments:
     scenario: "privesc-one-hop/to-admin/emr-serverless-001-iam-passrole+emr-serverless-createapplication+emr-serverless-startjobrun"
     description: "Deploy Terraform scenarios individually or in groups, each with attack and cleanup scripts"
 
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/c610d9ac3157a8ffd3ca43353febc5817e50fb86/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L381
+
 attackVisualization:
   nodes:
     - id: start

--- a/data/paths/gamelift/gamelift-001.yaml
+++ b/data/paths/gamelift/gamelift-001.yaml
@@ -156,6 +156,9 @@ learningEnvironments:
     scenario: "privesc-one-hop/to-admin/gamelift-001-iam-passrole+gamelift-createbuild+gamelift-createfleet"
     description: "Deploy Terraform scenarios individually or in groups, each with attack and cleanup scripts"
 
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/c610d9ac3157a8ffd3ca43353febc5817e50fb86/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L387
+
 attackVisualization:
   nodes:
     - id: start

--- a/data/paths/glue/glue-007.yaml
+++ b/data/paths/glue/glue-007.yaml
@@ -136,6 +136,9 @@ learningEnvironments:
     scenario: "privesc-one-hop/to-admin/glue-007-iam-passrole+glue-createsession+glue-runstatement"
     description: "Deploy Terraform scenarios individually or in groups, each with attack and cleanup scripts"
 
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/c610d9ac3157a8ffd3ca43353febc5817e50fb86/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L394
+
 attackVisualization:
   nodes:
   - id: start

--- a/data/paths/imagebuilder/imagebuilder-001.yaml
+++ b/data/paths/imagebuilder/imagebuilder-001.yaml
@@ -162,6 +162,9 @@ learningEnvironments:
     scenario: "privesc-one-hop/to-admin/imagebuilder-001-iam-passrole+imagebuilder-createcomponent+imagebuilder-createimagerecipe+imagebuilder-createinfrastructureconfiguration+imagebuilder-createimage"
     description: "Deploy Terraform scenarios individually or in groups, each with attack and cleanup scripts"
 
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/c610d9ac3157a8ffd3ca43353febc5817e50fb86/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L400
+
 attackVisualization:
   nodes:
     - id: start

--- a/data/paths/kinesisanalytics/kinesisanalytics-001.yaml
+++ b/data/paths/kinesisanalytics/kinesisanalytics-001.yaml
@@ -133,6 +133,9 @@ learningEnvironments:
     scenario: "privesc-one-hop/to-admin/kinesisanalytics-001-iam-passrole+kinesisanalytics-createapplication+kinesisanalytics-startapplication"
     description: "Deploy Terraform scenarios individually or in groups, each with attack and cleanup scripts"
 
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/c610d9ac3157a8ffd3ca43353febc5817e50fb86/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L408
+
 attackVisualization:
   nodes:
     - id: start

--- a/data/paths/omics/omics-001.yaml
+++ b/data/paths/omics/omics-001.yaml
@@ -166,6 +166,9 @@ learningEnvironments:
     scenario: "privesc-one-hop/to-admin/omics-001-iam-passrole+omics-createworkflow+omics-startrun"
     description: "Deploy Terraform scenarios individually or in groups, each with attack and cleanup scripts"
 
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/c610d9ac3157a8ffd3ca43353febc5817e50fb86/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L414
+
 attackVisualization:
   nodes:
     - id: start

--- a/data/paths/scheduler/scheduler-001.yaml
+++ b/data/paths/scheduler/scheduler-001.yaml
@@ -103,6 +103,9 @@ learningEnvironments:
     scenario: "privesc-one-hop/to-admin/scheduler-001"
     description: "Deploy Terraform scenarios individually or in groups, each with attack and cleanup scripts"
 
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/c610d9ac3157a8ffd3ca43353febc5817e50fb86/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L421
+
 attackVisualization:
   nodes:
     - id: start

--- a/data/paths/ssm/ssm-003.yaml
+++ b/data/paths/ssm/ssm-003.yaml
@@ -154,6 +154,9 @@ learningEnvironments:
     scenario: "privesc-one-hop/to-admin/ssm-003-ssm-createdocument+ssm-startautomationexecution"
     description: "Deploy Terraform scenarios individually or in groups, each with attack and cleanup scripts"
 
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/c610d9ac3157a8ffd3ca43353febc5817e50fb86/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L426
+
 attackVisualization:
   nodes:
   - id: start

--- a/data/paths/stepfunctions/stepfunctions-001.yaml
+++ b/data/paths/stepfunctions/stepfunctions-001.yaml
@@ -125,6 +125,9 @@ learningEnvironments:
     scenario: "privesc-one-hop/to-admin/stepfunctions-001-iam-passrole+states-createstatemachine+states-startexecution"
     description: "Deploy Terraform scenarios individually or in groups, each with attack and cleanup scripts"
 
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/c610d9ac3157a8ffd3ca43353febc5817e50fb86/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L432
+
 attackVisualization:
   nodes:
     - id: start

--- a/data/paths/stepfunctions/stepfunctions-002.yaml
+++ b/data/paths/stepfunctions/stepfunctions-002.yaml
@@ -104,6 +104,9 @@ learningEnvironments:
     githubLink: https://github.com/DataDog/pathfinding-labs
     scenario: "privesc-one-hop/to-admin/stepfunctions-002-states-updatestatemachine+states-startexecution"
     description: "Deploy Terraform scenarios individually or in groups, each with attack and cleanup scripts"
+detectionTools:
+  prowler: https://github.com/prowler-cloud/prowler/blob/c610d9ac3157a8ffd3ca43353febc5817e50fb86/prowler/providers/aws/services/iam/lib/privilege_escalation.py#L438
+
 attackVisualization:
   nodes:
     - id: start


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] New Path
- [x] Add / Update / Fix info within an existing path
- [ ] New Feature / Major Change / Refactor / Optimization
- [ ] Non path based documentation Update (Readme, etc)

## Description

Adds `prowler:` detection tool links to **17 existing attack paths** that Prowler now detects, following the merge of new privilege-escalation coverage into Prowler's IAM check (`prowler/providers/aws/services/iam/lib/privilege_escalation.py`). This is a follow-up to #10 / #11, covering the service-based PassRole and existing-resource escalation patterns that were added to Prowler afterwards.

Each link is pinned to Prowler `master` commit `c610d9ac3157a8ffd3ca43353febc5817e50fb86` at the exact line where the permission combination is defined.

**17 paths updated (new `detectionTools` section with `prowler:` link):**

| Path | Prowler pattern |
|------|-----------------|
| `batch-001` | `iam:PassRole` + `batch:RegisterJobDefinition` + `batch:SubmitJob` |
| `batch-002` | `batch:SubmitJob` (existing job definition) |
| `braket-001` | `iam:PassRole` + `braket:CreateJob` |
| `codedeploy-001` | `codedeploy:CreateDeployment` + `codedeploy:RegisterApplicationRevision` |
| `cognitoidentity-001` | `iam:PassRole` + `cognito-identity:SetIdentityPoolRoles` |
| `ecs-009` | `iam:PassRole` + `ecs:StartTask` (existing cluster) |
| `emr-001` | `iam:PassRole` + `elasticmapreduce:RunJobFlow` |
| `emrserverless-001` | `iam:PassRole` + `emr-serverless:CreateApplication` + `StartJobRun` |
| `gamelift-001` | `iam:PassRole` + `gamelift:CreateBuild` + `CreateFleet` |
| `glue-007` | `iam:PassRole` + `glue:CreateSession` + `RunStatement` |
| `imagebuilder-001` | `iam:PassRole` + `imagebuilder:CreateComponent` + `CreateImage` |
| `kinesisanalytics-001` | `iam:PassRole` + `kinesisanalytics:CreateApplication` + `StartApplication` |
| `omics-001` | `iam:PassRole` + `omics:CreateWorkflow` + `StartRun` |
| `scheduler-001` | `iam:PassRole` + `scheduler:CreateSchedule` |
| `ssm-003` | `iam:PassRole` + `ssm:CreateDocument` + `StartAutomationExecution` |
| `stepfunctions-001` | `iam:PassRole` + `states:CreateStateMachine` + `StartExecution` |
| `stepfunctions-002` | `states:UpdateStateMachine` + `StartExecution` (existing state machine) |

**Not included:**
- `sts-001` (`sts:AssumeRole`) — still commented out in Prowler pending resource/condition validation (same reason it was skipped in #10), so there is no stable source line to link yet.

## How to reproduce and testing

```bash
python scripts/validate-schema.py data/paths/
# Results: 87 passed, 0 failed out of 87 total
```