### PR TITLE
Fix attribution in ecs-007 and ecs-008

### DIFF
--- a/data/paths/ecs/ecs-007.yaml
+++ b/data/paths/ecs/ecs-007.yaml
@@ -140,7 +140,8 @@ limitations: |
 
 discoveryAttribution:
   firstDocumented:
-    source: ReverseC Labs
+    author: Tom Taylor-MacLean and Mohit Gupta
+    organization: Reversec
     date: 2025
     link: https://labs.reversec.com/posts/2025/08/another-ecs-privilege-escalation-path
 

--- a/data/paths/ecs/ecs-008.yaml
+++ b/data/paths/ecs/ecs-008.yaml
@@ -116,7 +116,8 @@ limitations: |
 
 discoveryAttribution:
   firstDocumented:
-    source: ReverseC Labs
+    author: Tom Taylor-MacLean and Mohit Gupta
+    organization: Reversec
     date: 2025
     link: https://labs.reversec.com/posts/2025/08/another-ecs-privilege-escalation-path
   derivativeOf:


### PR DESCRIPTION
## Summary
- Adds proper author attribution (Tom Taylor-MacLean and Mohit Gupta) to the discoveryAttribution section for ecs-007 and ecs-008
- Fixes organization name capitalization from "ReverseC Labs" to "Reversec"

## Test plan
- [x] Validated both YAML files with `scripts/validate-schema.py`
- [x] Regenerated `docs/paths.json` via `scripts/generate-json.py`