### PR TITLE
Prevent fork PR comment failures from blocking schema validation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -31,6 +31,7 @@ jobs:
 
       - name: Comment on PR (on failure)
         if: failure()
+        continue-on-error: true
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
@@ -56,6 +57,7 @@ jobs:
 
       - name: Comment on PR (on success)
         if: success()
+        continue-on-error: true
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |


### PR DESCRIPTION
## Summary
- PRs from forks get a read-only `GITHUB_TOKEN` from GitHub regardless of the `permissions:` block in the workflow, so the "Comment on PR" steps 403 with `Resource not accessible by integration`.
- This was failing the whole `validate` job (and thus the required status check) even when schema validation itself passed cleanly.
- Adds `continue-on-error: true` to both comment steps so a failed comment doesn't block merging, without granting forks any elevated permissions (no `pull_request_target`, no workflow permission changes).

## Test plan
- [x] Confirmed `deploy.yml` (GitHub Pages deploy) is unaffected — it only triggers on push to `main`, unrelated workflow
- [ ] Open a PR from a fork (or re-run PR #35's failed job) to confirm the job now succeeds when validation passes