### PR TITLE
fix(bedrock-005): remove memory permissions not required when memory is disabled

### DIFF
--- a/data/paths/bedrock/bedrock-005.yaml
+++ b/data/paths/bedrock/bedrock-005.yaml
@@ -1,5 +1,5 @@
 id: bedrock-005
-name: iam:PassRole + bedrock-agentcore:CreateHarness + bedrock-agentcore:CreateAgentRuntime + bedrock-agentcore:CreateAgentRuntimeEndpoint + bedrock-agentcore:CreateWorkloadIdentity + bedrock-agentcore:CreateMemory + bedrock-agentcore:GetMemory + bedrock-agentcore:GetAgentRuntime + bedrock-agentcore:GetHarness + bedrock-agentcore:InvokeAgentRuntimeCommand
+name: iam:PassRole + bedrock-agentcore:CreateHarness + bedrock-agentcore:CreateAgentRuntime + bedrock-agentcore:CreateAgentRuntimeEndpoint + bedrock-agentcore:CreateWorkloadIdentity + bedrock-agentcore:GetAgentRuntime + bedrock-agentcore:GetHarness + bedrock-agentcore:InvokeAgentRuntimeCommand
 category: new-passrole
 services:
 - iam
@@ -16,10 +16,6 @@ permissions:
     resourceConstraints: Required to create the runtime endpoint the harness uses
   - permission: bedrock-agentcore:CreateWorkloadIdentity
     resourceConstraints: Required to create the workload identity the underlying runtime needs
-  - permission: bedrock-agentcore:CreateMemory
-    resourceConstraints: AWS requires this permission on every CreateHarness call regardless of the memory configuration chosen, including when memory is explicitly disabled
-  - permission: bedrock-agentcore:GetMemory
-    resourceConstraints: Required alongside CreateMemory as part of CreateHarness's managed-memory provisioning
   - permission: bedrock-agentcore:GetAgentRuntime
     resourceConstraints: Required to resolve the runtime that CreateHarness provisions before invoking it
   - permission: bedrock-agentcore:GetHarness
@@ -62,7 +58,7 @@ exploitationSteps:
         --memory '{"disabled":{}}')
       HARNESS_ARN=$(echo "$CREATE_OUTPUT" | jq -r .harness.arn)
       HARNESS_ID=$(echo "$CREATE_OUTPUT" | jq -r .harness.harnessId)
-    description: Create a harness with the privileged execution role. CreateHarness provisions a runtime, endpoint, workload identity and memory resource under the hood, hence the longer permission chain. Memory is disabled since this attack never uses the managed agent loop, but AWS still requires the memory-related permissions on every CreateHarness call
+    description: Create a harness with the privileged execution role. CreateHarness provisions a runtime, endpoint and workload identity under the hood, hence the longer permission chain. Memory is disabled because the attack never uses the managed agent loop
   - step: 3
     command: |
       while true; do
@@ -255,7 +251,8 @@ attackVisualization:
       aws bedrock-agentcore-control create-harness \
         --harness-name atk_harness \
         --execution-role-arn $EXECUTION_ROLE \
-        --model '{"bedrockModelConfig":{"modelId":"<model-id>"}}'
+        --model '{"bedrockModelConfig":{"modelId":"<model-id>"}}' \
+        --memory '{"disabled":{}}'
       ```
   - from: harness
     to: target_role


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] New Path
- [x] Add / Update / Fix info within an existing path
- [ ] New Feature / Major Change / Refactor / Optimization
- [ ] Non path based documentation Update (Readme, etc)

## Description

`bedrock-005` lists `bedrock-agentcore:CreateMemory` and `bedrock-agentcore:GetMemory` as required, on the basis that AWS requires them on every `CreateHarness` call regardless of the memory configuration. That does not hold when memory is disabled, which is what the path's own step 2 does.

| Change | Detail |
| --- | --- |
| `permissions.required` | Removed `bedrock-agentcore:CreateMemory` and `bedrock-agentcore:GetMemory` |
| `name` | Dropped the same two permissions from the path name |
| Step 2 description | Removed the claim that AWS requires the memory permissions on every call |
| `attackVisualization` | Added the missing `--memory '{"disabled":{}}'` to the `create-harness` command so it matches step 2 |

## How to reproduce and testing

Validated in a sandbox account with a role holding only the permissions this path lists, and no `CreateMemory` or `GetMemory`:

- `create-harness` with `--memory '{"disabled":{}}'` reaches `READY`, and `GetHarness` reports `memory: {"disabled":{}}` on the created resource
- the rest of the chain works unchanged with that same role: `InvokeAgentRuntimeCommand` returns the MMDS payload and the credentials resolve to the harness execution role
- omitting the flag fails asynchronously with `CREATE_FAILED` and `Memory operation failed: ... not authorized to perform: bedrock-agentcore:CreateMemory`

So the memory permissions belong to the managed memory default rather than to `CreateHarness` itself. The same permission set is applied to the matching scenario in DataDog/pathfinding-labs#98, where the full attack was run end to end against it.

`python scripts/validate-schema.py data/paths/bedrock/bedrock-005.yaml` passes.
